### PR TITLE
chore: bump ext-php-rs to 0.15.12 and migrate to builder API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,29 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.111",
- "which 4.4.2",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,31 +419,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -703,17 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +678,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -820,15 +766,24 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -991,9 +946,9 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1001,27 +956,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1029,6 +983,22 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1195,37 +1165,78 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs"
-version = "0.13.1"
+version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ebc08b233139f41c0aa0c9005510a5988f5524e215eec8fd5f97a96fb3aac2"
+checksum = "0525834a3e26fdf0a60a8e7c27ec9521a35808eba8e41a15e135c22f670bc937"
 dependencies = [
  "anyhow",
- "bindgen",
  "bitflags 2.10.0",
  "cc",
  "cfg-if 1.0.4",
+ "ext-php-rs-bindgen",
+ "ext-php-rs-build",
  "ext-php-rs-derive",
+ "inventory",
  "native-tls",
  "once_cell",
  "parking_lot",
  "skeptic",
- "ureq 2.12.1",
- "zip 0.6.6",
+ "ureq",
+ "zip 8.5.1",
+]
+
+[[package]]
+name = "ext-php-rs-bindgen"
+version = "0.72.1-extphprs.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4795dd0976bd7d7d321c49e88e836f8e5b5b2b481e089067e303f2945617458a"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "ext-php-rs-clang-sys",
+ "itertools 0.14.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ext-php-rs-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561bce8a6312a6182c078cd987d8d9cb6bf9292a35817cfd009ea0bffa794f5f"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "ext-php-rs-clang-sys"
+version = "1.8.1-extphprs.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ad6e482017d457d57d73691f8bed148a8a6198babe90830310c3308480a61"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
 name = "ext-php-rs-derive"
-version = "0.10.2"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee71f9125d01946f305868b6269042c6a4dc061f68ad34e2a151ea478f5b3ee"
+checksum = "f6cb94d5f4c1e9758b6b936ad306dea36a034c125334d9a438fe966a5d596a85"
 dependencies = [
- "anyhow",
+ "convert_case 0.11.0",
  "darling",
- "ident_case",
- "lazy_static",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1278,7 +1289,7 @@ checksum = "f076483fb6efcf02e4abcf3e9388d30123346f85b9a96e8fe834718951b945ed"
 dependencies = [
  "anyhow",
  "tar",
- "ureq 3.2.0",
+ "ureq",
  "xz2",
  "zip 4.6.1",
 ]
@@ -1431,8 +1442,23 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if 1.0.4",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1674,15 +1700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1946,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2050,12 +2082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lddtree"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2091,12 @@ dependencies = [
  "glob",
  "goblin 0.10.4",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lebe"
@@ -2175,7 +2207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
@@ -2185,6 +2217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
  "crc",
+ "sha2",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+dependencies = [
  "sha2",
 ]
 
@@ -2625,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -3020,17 +3061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,21 +3074,22 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
+name = "pem-rfc7468"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "pep440_rs"
@@ -3309,6 +3340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,6 +3580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,7 +3778,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d2eccd988a924a470a76fbd81a191b22d1f5f4f4619cf5662a8c1ab4ca1db7"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "fnv",
  "ident_case",
  "indexmap",
@@ -4239,12 +4282,6 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4432,22 +4469,23 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-skia"
@@ -4675,6 +4713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4742,32 +4786,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "url",
-]
-
-[[package]]
-name = "ureq"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64",
+ "der",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -4868,7 +4901,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4961,6 +5003,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -5090,6 +5166,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5226,18 +5311,6 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -5711,6 +5784,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.111",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5903,26 +6064,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2 0.4.4",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zip"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
@@ -5959,15 +6100,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "arbitrary",
- "bzip2 0.6.1",
+ "bzip2",
  "crc32fast",
  "flate2",
  "indexmap",
- "lzma-rust2",
+ "lzma-rust2 0.13.0",
  "memchr",
  "time",
  "zopfli",
- "zstd 0.13.3",
+ "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "8.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+dependencies = [
+ "aes",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.2",
+ "hmac",
+ "indexmap",
+ "lzma-rust2 0.16.2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -5996,30 +6164,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ maturin = { version = "1", optional = true, default-features = false }
 pyo3 = { version = "0.25.0", optional = true, features = ["extension-module"] }
 
 # PHP dependencies
-ext-php-rs = { version = "0.13.1", optional = true }
+ext-php-rs = { version = "0.15.12", optional = true }
 
 # Scripting engine dependencies
 mlua = { version = "0.10", features = ["luajit", "vendored"], optional = true }

--- a/src/php.rs
+++ b/src/php.rs
@@ -12,6 +12,32 @@ use crate::{
 use ext_php_rs::prelude::*;
 use std::collections::HashMap;
 
+fn load_universal(bytes: &[u8]) -> PhpResult<UniversalSchematic> {
+    if litematic::is_litematic(bytes) {
+        litematic::from_litematic(bytes)
+            .map_err(|e| PhpException::default(format!("Failed to load litematic: {}", e)))
+    } else if schematic::is_schematic(bytes) {
+        schematic::from_schematic(bytes)
+            .map_err(|e| PhpException::default(format!("Failed to load schematic: {}", e)))
+    } else {
+        Err(PhpException::default(
+            "Unknown or unsupported format".to_string(),
+        ))
+    }
+}
+
+fn export_universal(schematic: &UniversalSchematic, format: &str) -> PhpResult<Vec<u8>> {
+    match format.to_lowercase().as_str() {
+        "litematic" => litematic::to_litematic(schematic)
+            .map_err(|e| PhpException::default(format!("Failed to export to litematic: {}", e))),
+        "schematic" => schematic::to_schematic(schematic)
+            .map_err(|e| PhpException::default(format!("Failed to export to schematic: {}", e))),
+        _ => Err(PhpException::default(
+            "Unsupported output format".to_string(),
+        )),
+    }
+}
+
 /// Simple test function to verify the extension works
 #[php_function]
 pub fn nucleation_hello() -> String {
@@ -21,7 +47,7 @@ pub fn nucleation_hello() -> String {
 /// Get version information
 #[php_function]
 pub fn nucleation_version() -> HashMap<String, String> {
-    let mut info = HashMap::new();
+    let mut info = HashMap::with_capacity(4);
     info.insert("version".to_string(), env!("CARGO_PKG_VERSION").to_string());
     info.insert(
         "description".to_string(),
@@ -49,33 +75,8 @@ pub fn nucleation_detect_format(data: String) -> String {
 /// Convert between schematic formats
 #[php_function]
 pub fn nucleation_convert_format(input_data: String, output_format: String) -> PhpResult<String> {
-    let bytes = input_data.as_bytes();
-
-    // Load the schematic based on input format
-    let schematic = if litematic::is_litematic(bytes) {
-        litematic::from_litematic(bytes)
-            .map_err(|e| PhpException::default(format!("Failed to load litematic: {}", e)))?
-    } else if schematic::is_schematic(bytes) {
-        schematic::from_schematic(bytes)
-            .map_err(|e| PhpException::default(format!("Failed to load schematic: {}", e)))?
-    } else {
-        return Err(PhpException::default("Unknown input format".to_string()));
-    };
-
-    // Convert to target format
-    let output_bytes = match output_format.to_lowercase().as_str() {
-        "litematic" => litematic::to_litematic(&schematic)
-            .map_err(|e| PhpException::default(format!("Failed to convert to litematic: {}", e)))?,
-        "schematic" => schematic::to_schematic(&schematic)
-            .map_err(|e| PhpException::default(format!("Failed to convert to schematic: {}", e)))?,
-        _ => {
-            return Err(PhpException::default(
-                "Unsupported output format".to_string(),
-            ))
-        }
-    };
-
-    // Convert bytes to string (this is not ideal but works for now)
+    let schematic = load_universal(input_data.as_bytes())?;
+    let output_bytes = export_universal(&schematic, &output_format)?;
     Ok(String::from_utf8_lossy(&output_bytes).to_string())
 }
 
@@ -98,87 +99,36 @@ impl NucleationSchematic {
 
     /// Load from binary data (auto-detect format)
     pub fn load_from_data(&mut self, data: String) -> PhpResult<bool> {
-        let bytes = data.as_bytes();
-
-        if litematic::is_litematic(bytes) {
-            match litematic::from_litematic(bytes) {
-                Ok(schematic) => {
-                    self.inner = schematic;
-                    Ok(true)
-                }
-                Err(e) => Err(PhpException::default(format!(
-                    "Failed to load litematic: {}",
-                    e
-                ))),
-            }
-        } else if schematic::is_schematic(bytes) {
-            match schematic::from_schematic(bytes) {
-                Ok(schematic) => {
-                    self.inner = schematic;
-                    Ok(true)
-                }
-                Err(e) => Err(PhpException::default(format!(
-                    "Failed to load schematic: {}",
-                    e
-                ))),
-            }
-        } else {
-            Err(PhpException::default(
-                "Unknown or unsupported format".to_string(),
-            ))
-        }
+        self.inner = load_universal(data.as_bytes())?;
+        Ok(true)
     }
 
     /// Load from litematic data
     pub fn from_litematic(&mut self, data: String) -> PhpResult<bool> {
-        let bytes = data.as_bytes();
-        match litematic::from_litematic(bytes) {
-            Ok(schematic) => {
-                self.inner = schematic;
-                Ok(true)
-            }
-            Err(e) => Err(PhpException::default(format!(
-                "Failed to load litematic: {}",
-                e
-            ))),
-        }
+        self.inner = litematic::from_litematic(data.as_bytes())
+            .map_err(|e| PhpException::default(format!("Failed to load litematic: {}", e)))?;
+        Ok(true)
     }
 
     /// Load from schematic data
     pub fn from_schematic(&mut self, data: String) -> PhpResult<bool> {
-        let bytes = data.as_bytes();
-        match schematic::from_schematic(bytes) {
-            Ok(schematic) => {
-                self.inner = schematic;
-                Ok(true)
-            }
-            Err(e) => Err(PhpException::default(format!(
-                "Failed to load schematic: {}",
-                e
-            ))),
-        }
+        self.inner = schematic::from_schematic(data.as_bytes())
+            .map_err(|e| PhpException::default(format!("Failed to load schematic: {}", e)))?;
+        Ok(true)
     }
 
     /// Export to litematic format
     pub fn to_litematic(&self) -> PhpResult<String> {
-        match litematic::to_litematic(&self.inner) {
-            Ok(data) => Ok(String::from_utf8_lossy(&data).to_string()),
-            Err(e) => Err(PhpException::default(format!(
-                "Failed to export to litematic: {}",
-                e
-            ))),
-        }
+        let data = litematic::to_litematic(&self.inner)
+            .map_err(|e| PhpException::default(format!("Failed to export to litematic: {}", e)))?;
+        Ok(String::from_utf8_lossy(&data).to_string())
     }
 
     /// Export to schematic format
     pub fn to_schematic(&self) -> PhpResult<String> {
-        match schematic::to_schematic(&self.inner) {
-            Ok(data) => Ok(String::from_utf8_lossy(&data).to_string()),
-            Err(e) => Err(PhpException::default(format!(
-                "Failed to export to schematic: {}",
-                e
-            ))),
-        }
+        let data = schematic::to_schematic(&self.inner)
+            .map_err(|e| PhpException::default(format!("Failed to export to schematic: {}", e)))?;
+        Ok(String::from_utf8_lossy(&data).to_string())
     }
 
     /// Set a block at coordinates
@@ -236,7 +186,7 @@ impl NucleationSchematic {
         z: i32,
     ) -> Option<HashMap<String, String>> {
         if let Some(block_state) = self.inner.get_block(x, y, z) {
-            let mut result = HashMap::new();
+            let mut result = HashMap::with_capacity(1 + block_state.properties.len());
             result.insert("name".to_string(), block_state.name.to_string());
             for (key, value) in &block_state.properties {
                 result.insert(key.to_string(), value.to_string());
@@ -270,7 +220,7 @@ impl NucleationSchematic {
 
     /// Get basic info
     pub fn get_info(&self) -> HashMap<String, String> {
-        let mut info = HashMap::new();
+        let mut info = HashMap::with_capacity(6);
 
         if let Some(name) = &self.inner.metadata.name {
             info.insert("name".to_string(), name.clone());
@@ -375,7 +325,7 @@ impl NucleationSchematic {
         self.inner
             .iter_blocks()
             .map(|(pos, block)| {
-                let mut block_info = HashMap::new();
+                let mut block_info = HashMap::with_capacity(5);
                 block_info.insert("x".to_string(), pos.x.to_string());
                 block_info.insert("y".to_string(), pos.y.to_string());
                 block_info.insert("z".to_string(), pos.z.to_string());
@@ -448,19 +398,7 @@ pub fn nucleation_create_schematic(name: String) -> NucleationSchematic {
 pub fn nucleation_load_from_file(file_path: String) -> PhpResult<NucleationSchematic> {
     let data = std::fs::read(&file_path)
         .map_err(|e| PhpException::default(format!("Failed to read file: {}", e)))?;
-
-    let inner = if litematic::is_litematic(&data) {
-        litematic::from_litematic(&data)
-            .map_err(|e| PhpException::default(format!("Failed to load litematic: {}", e)))?
-    } else if schematic::is_schematic(&data) {
-        schematic::from_schematic(&data)
-            .map_err(|e| PhpException::default(format!("Failed to load schematic: {}", e)))?
-    } else {
-        return Err(PhpException::default(
-            "Unknown or unsupported format".to_string(),
-        ));
-    };
-
+    let inner = load_universal(&data)?;
     Ok(NucleationSchematic { inner })
 }
 
@@ -471,17 +409,9 @@ pub fn nucleation_save_to_file(
     file_path: String,
     format: String,
 ) -> PhpResult<bool> {
-    let data = match format.to_lowercase().as_str() {
-        "litematic" => litematic::to_litematic(&schematic.inner)
-            .map_err(|e| PhpException::default(format!("Failed to export to litematic: {}", e)))?,
-        "schematic" => schematic::to_schematic(&schematic.inner)
-            .map_err(|e| PhpException::default(format!("Failed to export to schematic: {}", e)))?,
-        _ => return Err(PhpException::default("Unsupported format".to_string())),
-    };
-
+    let data = export_universal(&schematic.inner, &format)?;
     std::fs::write(&file_path, data)
         .map_err(|e| PhpException::default(format!("Failed to write file: {}", e)))?;
-
     Ok(true)
 }
 #[php_module]

--- a/src/php.rs
+++ b/src/php.rs
@@ -80,15 +80,16 @@ pub fn nucleation_convert_format(input_data: String, output_format: String) -> P
 }
 
 /// PHP class representing a Universal Schematic
-#[php_class(name = "Nucleation\\Schematic")]
+#[php_class]
+#[php(name = "Nucleation\\Schematic")]
 pub struct NucleationSchematic {
     inner: UniversalSchematic,
 }
 
 #[php_impl]
+#[php(change_method_case = "none")]
 impl NucleationSchematic {
     /// Constructor
-    #[php_method]
     pub fn __construct(name: Option<String>) -> NucleationSchematic {
         let schematic_name = name.unwrap_or_else(|| "Default".to_string());
         let inner = UniversalSchematic::new(schematic_name);
@@ -96,7 +97,6 @@ impl NucleationSchematic {
     }
 
     /// Load from binary data (auto-detect format)
-    #[php_method]
     pub fn load_from_data(&mut self, data: String) -> PhpResult<bool> {
         let bytes = data.as_bytes();
 
@@ -130,7 +130,6 @@ impl NucleationSchematic {
     }
 
     /// Load from litematic data
-    #[php_method]
     pub fn from_litematic(&mut self, data: String) -> PhpResult<bool> {
         let bytes = data.as_bytes();
         match litematic::from_litematic(bytes) {
@@ -146,7 +145,6 @@ impl NucleationSchematic {
     }
 
     /// Load from schematic data
-    #[php_method]
     pub fn from_schematic(&mut self, data: String) -> PhpResult<bool> {
         let bytes = data.as_bytes();
         match schematic::from_schematic(bytes) {
@@ -162,7 +160,6 @@ impl NucleationSchematic {
     }
 
     /// Export to litematic format
-    #[php_method]
     pub fn to_litematic(&self) -> PhpResult<String> {
         match litematic::to_litematic(&self.inner) {
             Ok(data) => Ok(String::from_utf8_lossy(&data).to_string()),
@@ -174,7 +171,6 @@ impl NucleationSchematic {
     }
 
     /// Export to schematic format
-    #[php_method]
     pub fn to_schematic(&self) -> PhpResult<String> {
         match schematic::to_schematic(&self.inner) {
             Ok(data) => Ok(String::from_utf8_lossy(&data).to_string()),
@@ -186,7 +182,6 @@ impl NucleationSchematic {
     }
 
     /// Set a block at coordinates
-    #[php_method]
     pub fn set_block(&mut self, x: i32, y: i32, z: i32, block_name: String) -> PhpResult<()> {
         let block_state = BlockState::new(block_name);
         self.inner.set_block(x, y, z, &block_state);
@@ -194,7 +189,6 @@ impl NucleationSchematic {
     }
 
     /// Set a block from a block string
-    #[php_method]
     pub fn set_block_from_string(
         &mut self,
         x: i32,
@@ -211,7 +205,6 @@ impl NucleationSchematic {
     }
 
     /// Set a block with properties
-    #[php_method]
     pub fn set_block_with_properties(
         &mut self,
         x: i32,
@@ -229,15 +222,13 @@ impl NucleationSchematic {
     }
 
     /// Get block at coordinates
-    #[php_method]
     pub fn get_block(&self, x: i32, y: i32, z: i32) -> Option<String> {
         self.inner
             .get_block(x, y, z)
-            .map(|block_state| block_state.name.clone())
+            .map(|block_state| block_state.name.to_string())
     }
 
     /// Get block with properties
-    #[php_method]
     pub fn get_block_with_properties(
         &self,
         x: i32,
@@ -246,9 +237,9 @@ impl NucleationSchematic {
     ) -> Option<HashMap<String, String>> {
         if let Some(block_state) = self.inner.get_block(x, y, z) {
             let mut result = HashMap::new();
-            result.insert("name".to_string(), block_state.name.clone());
+            result.insert("name".to_string(), block_state.name.to_string());
             for (key, value) in &block_state.properties {
-                result.insert(key.clone(), value.clone());
+                result.insert(key.to_string(), value.to_string());
             }
             Some(result)
         } else {
@@ -257,32 +248,27 @@ impl NucleationSchematic {
     }
 
     /// Get schematic dimensions
-    #[php_method]
     pub fn get_dimensions(&self) -> Vec<i32> {
         let (x, y, z) = self.inner.get_dimensions();
         vec![x, y, z]
     }
 
     /// Get total block count
-    #[php_method]
     pub fn get_block_count(&self) -> i32 {
         self.inner.total_blocks()
     }
 
     /// Get total volume
-    #[php_method]
     pub fn get_volume(&self) -> i32 {
         self.inner.total_volume()
     }
 
     /// Get region names
-    #[php_method]
     pub fn get_region_names(&self) -> Vec<String> {
         self.inner.get_region_names()
     }
 
     /// Get basic info
-    #[php_method]
     pub fn get_info(&self) -> HashMap<String, String> {
         let mut info = HashMap::new();
 
@@ -315,58 +301,49 @@ impl NucleationSchematic {
     }
 
     /// Set metadata name
-    #[php_method]
     pub fn set_metadata_name(&mut self, name: String) -> PhpResult<()> {
         self.inner.metadata.name = Some(name);
         Ok(())
     }
 
     /// Get metadata name
-    #[php_method]
     pub fn get_metadata_name(&self) -> Option<String> {
         self.inner.metadata.name.clone()
     }
 
     /// Set metadata author
-    #[php_method]
     pub fn set_metadata_author(&mut self, author: String) -> PhpResult<()> {
         self.inner.metadata.author = Some(author);
         Ok(())
     }
 
     /// Get metadata author
-    #[php_method]
     pub fn get_metadata_author(&self) -> Option<String> {
         self.inner.metadata.author.clone()
     }
 
     /// Set metadata description
-    #[php_method]
     pub fn set_metadata_description(&mut self, description: String) -> PhpResult<()> {
         self.inner.metadata.description = Some(description);
         Ok(())
     }
 
     /// Get metadata description
-    #[php_method]
     pub fn get_metadata_description(&self) -> Option<String> {
         self.inner.metadata.description.clone()
     }
 
     /// Format the schematic as a human-readable string
-    #[php_method]
     pub fn format(&self) -> String {
         format_schematic(&self.inner)
     }
 
     /// Format the schematic as JSON
-    #[php_method]
     pub fn format_json(&self) -> String {
         format_json_schematic(&self.inner)
     }
 
     /// Get debug information
-    #[php_method]
     pub fn debug_info(&self) -> String {
         format!(
             "Schematic name: {}, Regions: {}",
@@ -380,7 +357,6 @@ impl NucleationSchematic {
     }
 
     /// Convert to string representation
-    #[php_method]
     #[allow(non_snake_case)]
     pub fn __toString(&self) -> String {
         format!(
@@ -395,7 +371,6 @@ impl NucleationSchematic {
     }
 
     /// Get all blocks as array
-    #[php_method]
     pub fn get_all_blocks(&self) -> Vec<HashMap<String, String>> {
         self.inner
             .iter_blocks()
@@ -404,7 +379,7 @@ impl NucleationSchematic {
                 block_info.insert("x".to_string(), pos.x.to_string());
                 block_info.insert("y".to_string(), pos.y.to_string());
                 block_info.insert("z".to_string(), pos.z.to_string());
-                block_info.insert("name".to_string(), block.name.clone());
+                block_info.insert("name".to_string(), block.name.to_string());
 
                 // Add properties as a JSON string for simplicity
                 if !block.properties.is_empty() {
@@ -418,7 +393,6 @@ impl NucleationSchematic {
     }
 
     /// Copy a region from another schematic
-    #[php_method]
     pub fn copy_region(
         &mut self,
         from_schematic: &NucleationSchematic,
@@ -513,4 +487,12 @@ pub fn nucleation_save_to_file(
 #[php_module]
 pub fn module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        .class::<NucleationSchematic>()
+        .function(wrap_function!(nucleation_hello))
+        .function(wrap_function!(nucleation_version))
+        .function(wrap_function!(nucleation_detect_format))
+        .function(wrap_function!(nucleation_convert_format))
+        .function(wrap_function!(nucleation_create_schematic))
+        .function(wrap_function!(nucleation_load_from_file))
+        .function(wrap_function!(nucleation_save_to_file))
 }


### PR DESCRIPTION
v0.14 replaced the global-state macro system with an explicit
ModuleBuilder API, so the module function now registers the
NucleationSchematic class and the 7 free functions via
wrap_function! and .class::<T>().

Other required changes:
- #[php_class(name = ...)] args moved to #[php(name = ...)]
- #[php_method] no longer exists, removed from all 23 methods
- pin snake_case PHP API via #[php(change_method_case = "none")]
  to keep userland BC

Fix a latent SmolStr to String mismatch in get_block,
get_block_with_properties and get_all_blocks that was hidden by
0.13 failing to build on systems without PHP dev headers.